### PR TITLE
API contract tests, artifact endpoints, OpenAPI, worker queue + disk persistence

### DIFF
--- a/services/api/openapi.json
+++ b/services/api/openapi.json
@@ -1,0 +1,72 @@
+{
+  "openapi": "3.0.3",
+  "info": {
+    "title": "Finance Research Agent API",
+    "version": "0.1.0"
+  },
+  "paths": {
+    "/runs": {
+      "post": {
+        "summary": "Start a new run",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "company_name": {"type": "string"}
+                },
+                "required": ["company_name"]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Run queued",
+            "content": {"application/json": {"schema": {"type": "object"}}}
+          },
+          "400": {"description": "Validation error"},
+          "401": {"description": "Unauthorized"},
+          "429": {"description": "Rate limited"}
+        }
+      }
+    },
+    "/runs/{id}": {
+      "get": {
+        "summary": "Get run status",
+        "parameters": [
+          {"name": "id", "in": "path", "required": true, "schema": {"type": "string"}}
+        ],
+        "responses": {
+          "200": {"description": "Run info"},
+          "404": {"description": "Not found"},
+          "401": {"description": "Unauthorized"}
+        }
+      }
+    },
+    "/runs/{id}/artifacts/{name}": {
+      "get": {
+        "summary": "Download artifact",
+        "parameters": [
+          {"name": "id", "in": "path", "required": true, "schema": {"type": "string"}},
+          {"name": "name", "in": "path", "required": true, "schema": {"type": "string"}}
+        ],
+        "responses": {
+          "200": {"description": "Artifact content"},
+          "404": {"description": "Not found"},
+          "401": {"description": "Unauthorized"}
+        }
+      }
+    },
+    "/runs/{id}/events": {
+      "get": {
+        "summary": "WebSocket endpoint for events",
+        "description": "Upgrade to WebSocket to receive events",
+        "responses": {"101": {"description": "Switching Protocols"}}
+      }
+    }
+  }
+}
+

--- a/services/api/server.py
+++ b/services/api/server.py
@@ -1,9 +1,95 @@
 from __future__ import annotations
 from typing import Any
-from flask import Flask, request, jsonify
-from services.api.orchestrator import REGISTRY, start_run
+from flask import Flask, request, jsonify, Response
+from services.api.orchestrator import REGISTRY, start_run, ARTIFACTS_ROOT
+
+import os
+import io
+import zipfile
+
+import time
+import json
+from collections import deque, defaultdict
+try:
+    from flask_sock import Sock
+except Exception:  # pragma: no cover
+    Sock = None  # Optional dependency for WS
 
 app = Flask(__name__)
+
+# Configuration helpers (overridable via app.config in tests)
+
+def _get_api_key() -> str | None:
+    if 'API_KEY' in app.config:
+        return app.config.get('API_KEY')
+    return os.environ.get('API_KEY')
+
+
+def _get_rate_limit() -> tuple[int, float]:
+    n = app.config.get('RATE_LIMIT_N')
+    w = app.config.get('RATE_LIMIT_WINDOW_SEC')
+    if n is None:
+        n = int(os.environ.get('RATE_LIMIT_N', '5'))
+    if w is None:
+        w = float(os.environ.get('RATE_LIMIT_WINDOW_SEC', '1.0'))
+    return int(n), float(w)
+
+_recent: dict[str, deque[float]] = defaultdict(lambda: deque(maxlen=100))
+
+# Optional WebSocket support
+if Sock is not None:
+    sock = Sock(app)
+else:
+    sock = None
+def _client_ip() -> str:
+    xff = request.headers.get('X-Forwarded-For')
+    if xff:
+        return xff.split(',')[0].strip()
+    return request.remote_addr or 'anon'
+
+
+def _check_api_key():
+    api_key = _get_api_key()
+    if api_key:
+        provided = request.headers.get('X-API-Key')
+        if provided != api_key:
+            return jsonify({'error': 'unauthorized'}), 401
+    return None
+
+
+def _check_rate_limit(ip: str):
+    # Allow if rate limiting disabled or N <= 0
+    n, window = _get_rate_limit()
+    if n <= 0:
+        return None
+    now = time.time()
+    dq = _recent[ip]
+    # Drop old entries outside window
+    while dq and now - dq[0] > window:
+        dq.popleft()
+    if len(dq) >= n:
+        retry = max(0.0, window - (now - dq[0]))
+        resp = jsonify({'error': 'rate_limited'})
+        resp.status_code = 429
+        resp.headers['Retry-After'] = f"{retry:.2f}"
+        return resp
+    dq.append(now)
+    return None
+
+@app.before_request
+def _auth_and_rate_limit():
+    # Only enforce for API routes under /runs; skip static or root
+    if request.path.startswith('/runs'):
+        # Auth
+        unauthorized = _check_api_key()
+        if unauthorized is not None:
+            return unauthorized
+        # Rate limit only for POST /runs
+        if request.method == 'POST' and request.path == '/runs':
+            rl = _check_rate_limit(_client_ip())
+            if rl is not None:
+                return rl
+    return None
 
 @app.post('/runs')
 def post_runs():
@@ -27,6 +113,93 @@ def get_run(rid: str):
         'events': r.events,
         'error': r.error,
     })
+@app.get('/runs/<rid>/artifacts/<name>')
+def get_artifact(rid: str, name: str):
+    r = REGISTRY.get(rid)
+    if not r:
+        return jsonify({'error': 'not_found'}), 404
+    body = r.artifacts.get(name)
+    if body is None:
+        return jsonify({'error': 'artifact_not_found'}), 404
+    # Basic content-type inference for MVP
+    if name.endswith('.csv'):
+        mimetype = 'text/csv'
+    elif name.endswith('.md'):
+        mimetype = 'text/markdown'
+    else:
+        mimetype = 'application/octet-stream'
+    return Response(body, mimetype=mimetype)
+# Optional: OpenAPI spec route (serves static JSON file)
+@app.get('/openapi.json')
+def get_openapi():
+    try:
+        with open('services/api/openapi.json', 'r') as f:
+            spec = json.load(f)
+        return jsonify(spec)
+    except Exception:
+        return jsonify({'error': 'openapi_not_found'}), 404
+
+# Optional: WebSocket for events stream (if flask-sock installed)
+if sock is not None:
+    @sock.route('/runs/<rid>/events')
+    def ws_events(ws, rid):  # pragma: no cover (basic smoke only)
+        r = REGISTRY.get(rid)
+        if not r:
+            ws.close()
+            return
+        last_idx = 0
+        # Stream existing then poll for new events for a short time
+        start = time.time()
+        while ws.connected and time.time() - start < 10:
+            evs = r.events
+            if last_idx < len(evs):
+                for ev in evs[last_idx:]:
+                    ws.send(json.dumps(ev))
+                last_idx = len(evs)
+            time.sleep(0.05)
+
+@app.get('/runs')
+def list_runs():
+    # List persisted runs from disk; ignore in-memory registry
+    try:
+        runs = []
+        if ARTIFACTS_ROOT.exists():
+            for p in sorted(ARTIFACTS_ROOT.iterdir()):
+                if p.is_dir() and (p / 'run.json').exists():
+                    try:
+                        meta = json.loads((p / 'run.json').read_text())
+                        runs.append({
+                            'run_id': meta.get('run_id') or p.name,
+                            'status': meta.get('status'),
+                            'summary': meta.get('summary'),
+                            'artifacts': meta.get('artifacts', []),
+                            'completed_at': meta.get('completed_at'),
+                        })
+                    except Exception:
+                        continue
+        return jsonify({'runs': runs})
+    except Exception:
+        return jsonify({'runs': []})
+
+@app.get('/runs/<rid>/download.zip')
+def download_zip(rid: str):
+    # Create a zip of all artifacts for a run
+    run_dir = ARTIFACTS_ROOT / rid
+    if not run_dir.exists():
+        return jsonify({'error': 'not_found'}), 404
+    # Build zip in memory
+    mem = io.BytesIO()
+    with zipfile.ZipFile(mem, mode='w', compression=zipfile.ZIP_DEFLATED) as zf:
+        for child in run_dir.iterdir():
+            if child.is_file() and child.name != 'run.json':
+                zf.writestr(child.name, child.read_bytes())
+    mem.seek(0)
+    return Response(mem.getvalue(), mimetype='application/zip', headers={
+        'Content-Disposition': f'attachment; filename="{rid}.zip"'
+    })
+
+
+
 
 if __name__ == '__main__':
     app.run(host='0.0.0.0', port=8000)

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,0 +1,101 @@
+import unittest
+import time
+from typing import List
+
+from services.api.server import app
+
+
+class TestAPIRuns(unittest.TestCase):
+    def setUp(self):
+        app.testing = True
+        self.client = app.test_client()
+
+    def _wait_for_completion(self, rid: str, timeout_s: float = 5.0) -> dict:
+        deadline = time.time() + timeout_s
+        last = None
+        while time.time() < deadline:
+            rv = self.client.get(f"/runs/{rid}")
+            if rv.status_code != 200:
+                time.sleep(0.05)
+                continue
+            last = rv.get_json()
+            if last and last.get("status") in ("completed", "failed"):
+                return last
+            time.sleep(0.05)
+        return last or {}
+
+    def test_post_runs_requires_company_name(self):
+        rv = self.client.post("/runs", json={})
+        self.assertEqual(rv.status_code, 400)
+        body = rv.get_json()
+        self.assertEqual(body.get("error"), "company_name is required")
+
+    def test_post_and_get_run_contract_and_events(self):
+        # Create run
+        rv = self.client.post("/runs", json={"company_name": "Apple"})
+        self.assertEqual(rv.status_code, 200)
+        body = rv.get_json()
+        self.assertIn("run_id", body)
+        self.assertEqual(body.get("status"), "queued")
+        rid = body["run_id"]
+
+        # Poll until finished
+        final = self._wait_for_completion(rid)
+        self.assertIsNotNone(final)
+        self.assertIn(final.get("status"), ("completed", "failed"))
+        self.assertEqual(final.get("run_id"), rid)
+        self.assertIn("events", final)
+        self.assertIsInstance(final["events"], list)
+        self.assertIn("artifacts", final)
+        self.assertIsInstance(final["artifacts"], list)
+
+        # Verify event stage ordering (prefix order)
+        stages = [e.get("stage") for e in final["events"]]
+        expected_prefix: List[str] = [
+            "Resolve",
+            "Ingest",
+            "Map",
+            "Forecast",
+            "DCF",
+            "Export",
+        ]
+        # The run either completes (then 'Done' exists) or fails (then 'Error' exists)
+        # Validate that expected_prefix appears in order within stages
+        it = iter(stages)
+        for s in expected_prefix:
+            for t in it:
+                if t == s:
+                    break
+            else:
+                self.fail(f"Did not find stage '{s}' in order. Stages: {stages}")
+        # End stage check
+        self.assertTrue(stages[-1] in ("Done", "Error"))
+
+        # Basic artifact presence
+        arts = set(final["artifacts"])  # list of names
+        for name in ("dcf.csv", "income_statement.csv", "metadata.csv", "assumptions.md", "validation_report.md"):
+            self.assertIn(name, arts)
+
+        # Artifact download endpoint (csv)
+        rv_art = self.client.get(f"/runs/{rid}/artifacts/dcf.csv")
+        self.assertEqual(rv_art.status_code, 200)
+        self.assertIn(rv_art.mimetype, ("text/csv", "text/plain"))
+        self.assertIn("period_end,ebit,tax_rate", rv_art.get_data(as_text=True).splitlines()[0])
+
+    def test_404s(self):
+        rv = self.client.get("/runs/does-not-exist")
+        self.assertEqual(rv.status_code, 404)
+        rv2 = self.client.get("/runs/does-not-exist/artifacts/dcf.csv")
+        self.assertEqual(rv2.status_code, 404)
+
+        # Create a run and wait; then request a missing artifact
+        rv3 = self.client.post("/runs", json={"company_name": "Foo"})
+        rid = rv3.get_json()["run_id"]
+        self._wait_for_completion(rid)
+        rv_missing = self.client.get(f"/runs/{rid}/artifacts/missing.txt")
+        self.assertEqual(rv_missing.status_code, 404)
+
+
+if __name__ == "__main__":
+    unittest.main()
+

--- a/tests/test_api_extras.py
+++ b/tests/test_api_extras.py
@@ -1,0 +1,51 @@
+import unittest
+import importlib
+import services.api.server as server
+from services.api.server import app
+
+class TestAPIExtras(unittest.TestCase):
+    def setUp(self):
+        app.testing = True
+        # Clear API key and rate limiter state to avoid cross-test leakage
+        app.config['API_KEY'] = None
+        try:
+            server._recent.clear()
+        except Exception:
+            pass
+        self.client = app.test_client()
+
+    def test_openapi_endpoint(self):
+        rv = self.client.get('/openapi.json')
+        self.assertEqual(rv.status_code, 200)
+        spec = rv.get_json()
+        self.assertIn('openapi', spec)
+        self.assertIn('/runs', spec.get('paths', {}))
+
+    def test_rate_limit_post_runs(self):
+        # Ensure no auth for this test
+        app.config['API_KEY'] = None
+        # Override rate limit to a very small number for test
+        app.config['RATE_LIMIT_N'] = 1
+        app.config['RATE_LIMIT_WINDOW_SEC'] = 1.0
+        # First request should pass (but may 400 if missing company_name)
+        rv1 = self.client.post('/runs', json={'company_name': 'A'})
+        self.assertIn(rv1.status_code, (200, 400))
+        # Second immediate request should be 429
+        rv2 = self.client.post('/runs', json={'company_name': 'B'})
+        self.assertEqual(rv2.status_code, 429)
+        data = rv2.get_json()
+        self.assertEqual(data.get('error'), 'rate_limited')
+
+    def test_auth_api_key(self):
+        # Enable API key requirement
+        app.config['API_KEY'] = 'secret'
+        # Missing key -> 401
+        rv = self.client.get('/runs/not-exist')
+        self.assertEqual(rv.status_code, 401)
+        # With key -> proceeds to 404 for missing run
+        rv2 = self.client.get('/runs/not-exist', headers={'X-API-Key': 'secret'})
+        self.assertEqual(rv2.status_code, 404)
+
+if __name__ == '__main__':
+    unittest.main()
+

--- a/tests/test_runs_persistence.py
+++ b/tests/test_runs_persistence.py
@@ -1,0 +1,61 @@
+import os
+import time
+import json
+import shutil
+import unittest
+from pathlib import Path
+import services.api.server as server
+from services.api.orchestrator import ARTIFACTS_ROOT
+from services.api.server import app
+
+class TestRunsPersistence(unittest.TestCase):
+    def setUp(self):
+        app.testing = True
+        self.client = app.test_client()
+        # Clean artifacts dir before each test
+        if ARTIFACTS_ROOT.exists():
+            shutil.rmtree(ARTIFACTS_ROOT)
+        ARTIFACTS_ROOT.mkdir(parents=True, exist_ok=True)
+        # Disable auth and rate-limit for these tests
+        app.config['API_KEY'] = None
+        app.config['RATE_LIMIT_N'] = 0
+        try:
+            server._recent.clear()
+        except Exception:
+            pass
+
+    def _wait_done(self, rid: str, timeout=5.0):
+        deadline = time.time() + timeout
+        while time.time() < deadline:
+            rv = self.client.get(f"/runs/{rid}")
+            if rv.status_code == 200:
+                b = rv.get_json()
+                if b.get('status') in ('completed', 'failed'):
+                    return b
+            time.sleep(0.05)
+        return {}
+
+    def test_artifacts_written_to_disk_and_list_runs(self):
+        rv = self.client.post('/runs', json={'company_name': 'Apple'})
+        self.assertEqual(rv.status_code, 200)
+        rid = rv.get_json()['run_id']
+        final = self._wait_done(rid)
+        self.assertIn(final.get('status'), ('completed', 'failed'))
+        run_dir = ARTIFACTS_ROOT / rid
+        self.assertTrue((run_dir / 'run.json').exists())
+        # Basic expected artifacts
+        for name in ('dcf.csv','income_statement.csv','metadata.csv','assumptions.md','validation_report.md'):
+            self.assertTrue((run_dir / name).exists(), f"missing {name}")
+        # List runs endpoint
+        rv_list = self.client.get('/runs')
+        self.assertEqual(rv_list.status_code, 200)
+        runs = rv_list.get_json().get('runs', [])
+        self.assertTrue(any(r.get('run_id') == rid for r in runs))
+        # Zip download
+        rv_zip = self.client.get(f"/runs/{rid}/download.zip")
+        self.assertEqual(rv_zip.status_code, 200)
+        self.assertEqual(rv_zip.mimetype, 'application/zip')
+
+if __name__ == '__main__':
+    unittest.main()
+


### PR DESCRIPTION
Summary
- Add API contract tests for POST /runs and GET /runs/{id}, including stage ordering and artifact presence
- Implement artifact download endpoint GET /runs/{id}/artifacts/{name}
- Add OpenAPI spec at GET /openapi.json
- Add simple auth (X-API-Key) and rate limiting for POST /runs
- Add list runs endpoint GET /runs to read persisted run metadata from disk
- Add ZIP download endpoint GET /runs/{id}/download.zip for all artifacts
- Implement in-process multi-worker job queue with retry/backoff semantics
- Persist artifacts and metadata to disk under ./run_artifacts/<run_id>
- Tests cover contracts, auth/rate limit, persistence and zip download

Details
- services/api/server.py
  - POST /runs; GET /runs/{id}
  - GET /runs/{id}/artifacts/{name}
  - GET /openapi.json
  - GET /runs (list from disk)
  - GET /runs/{id}/download.zip
  - before_request adds API key auth and rate limit for POST /runs
  - Optional WS events route with flask-sock
- services/api/orchestrator.py
  - Minimal in-process job queue with configurable workers (JOB_WORKERS), retries (JOB_MAX_RETRIES) and exponential backoff (JOB_BACKOFF_BASE)
  - Persist artifacts and run.json to ./run_artifacts/<rid>
  - start_run() enqueues job into queue
- services/api/openapi.json: minimal spec for endpoints added
- tests/test_api.py: contract tests for POST/GET /runs, artifacts, event ordering
- tests/test_api_extras.py: tests for rate limiting, API key auth, and OpenAPI
- tests/test_runs_persistence.py: verifies disk persistence and ZIP download

Config
- API key via env or app.config['API_KEY']
- Rate limit via RATE_LIMIT_N, RATE_LIMIT_WINDOW_SEC
- Queue via JOB_WORKERS, JOB_MAX_RETRIES, JOB_BACKOFF_BASE
- Artifacts path via ARTIFACTS_ROOT (default ./run_artifacts)

Notes
- WS events route provided via flask-sock; integration tests omitted to avoid heavier test infra.
- This is an MVP queue/storage; Phase 8.3 acceptance (crash safety/resume) can be expanded in follow-ups.

Checklist
- [x] Unit tests pass locally (35 tests)
- [x] No external network calls; deterministic
- [x] OpenAPI served
- [x] Basic rate limiting and auth

Next phases
- Expand WS integration tests with a client if desired
- Consider pluggable persistent queue (e.g., Redis/RQ) and object storage abstraction
- Optional: include artifact bodies in GET /runs/{id} if UI needs it


---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author